### PR TITLE
Beautify tab1 content simply

### DIFF
--- a/assets/assets.css
+++ b/assets/assets.css
@@ -220,4 +220,34 @@ div.tab--selected:hover {
     margin-top: 17px;
 }
 
+/* ============================ Simple reusable panel styles ============================ */
+/* Used to lightly beautify sections on Tab 1 without over-engineering */
+.panel-card {
+    background-color: #2b2e35;
+    color: #c0c4cc;
+    border: 1px solid #3a3f4b;
+    border-radius: 12px;
+    padding: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.panel-title {
+    color: #c0c4cc;
+    font-weight: 500;
+    font-size: 16px;
+    padding: 8px 12px;
+    border-bottom: 1px solid #3a3f4b;
+    margin: 0;
+    text-align: center;
+}
+
+/* Avoid double-styling inside panel for checklist group */
+.panel-card .control-panel-1 {
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 8px 0;
+    margin-bottom: 8px;
+}
+
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -383,19 +383,18 @@ app.layout = dbc.Container([
                     dbc.Col(dcc.Loading(
                         id="loading-curve",
                         type="circle",
-                        children=html.Div(dcc.Graph(id='curve-plot', config={'scrollZoom': True, 'displayModeBar': False}),className="border p-1 my-2 rounded")
+                        children=html.Div(
+                            dcc.Graph(
+                                id='curve-plot',
+                                config={'scrollZoom': True, 'displayModeBar': False}
+                            ),
+                            className="panel-card my-2"
+                        )
                         ), width=10
                     ),
                     dbc.Col([
                         html.Div([
-                            html.H5(
-                                "Plot Controls",
-                                style={
-                                    "color": "#c0c4cc", "textAlign": "center", "padding": "8px 16px",
-                                    "backgroundColor": "#2b2e35", "fontWeight": "500", "fontSize": "16px",
-                                    "borderBottom": "1px solid #3a3f4b", "margin": "0"
-                                }
-                            ),
+                            html.H5("Plot Controls", className="panel-title"),
 
                             dbc.Checklist(
                                 id='plot-flags',
@@ -446,16 +445,10 @@ app.layout = dbc.Container([
                                     dbc.Col(dbc.Input(id="bb-std-input", type="number", value=1, min=1, step=1, debounce=True), width=6)
                                 ], id="bb-std-row", className="mb-2", style={"display": "none"}),
 
-                            ], gap=1)
+                            ], gap=2)
                         ],
-
-                        style={
-                            "border": "1px solid #3a3f4b",
-                            "borderRadius": "8px",
-                            "backgroundColor": "#2b2e35",
-                            "padding": "10px",
-                            "marginTop": "5px"
-                        })
+                        className="panel-card"
+                        )
                     ], width=2, style={"paddingLeft": "0px", "marginTop": "2px"})
                 ]),
             #]),
@@ -477,6 +470,7 @@ app.layout = dbc.Container([
                                 style={"width": "100%"},  # or use a maxHeight with scroll
                                 
                             ),
+                        className="panel-card",
                         style={"overflow": "hidden", "position": "relative"}  # container style
                         )
                     ), width=12)


### PR DESCRIPTION
Apply simple, reusable CSS styles to beautify Tab 1 content.

The user requested to beautify Tab 1 without over-engineering. This PR introduces `.panel-card` and `.panel-title` styles in `assets.css` and applies them to the graph container, controls panel, and table container in `dashboard.py` for a cleaner, consistent look.

---
<a href="https://cursor.com/background-agent?bcId=bc-3aacd9d2-7226-4545-8124-a2d8b7a4e3c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3aacd9d2-7226-4545-8124-a2d8b7a4e3c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

